### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dockerization.yml
+++ b/.github/workflows/dockerization.yml
@@ -1,5 +1,8 @@
 name: Dockerization of web application
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/PepperTechDev/PepperCRM-Web/security/code-scanning/1](https://github.com/PepperTechDev/PepperCRM-Web/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow does not modify repository contents, we can set `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit read-only permissions for repository contents.

The `permissions` block should be added at the root level of the workflow, immediately after the `name` field. No additional imports, methods, or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
